### PR TITLE
(SIMP-604) Migrate to simplib and simpcat

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,8 @@
 fixtures:
   repositories:
     common: "git://github.com/simp/pupmod-simp-common"
-    concat: "git://github.com/simp/pupmod-simp-concat"
+    simplib: "git://github.com/simp/pupmod-simp-simplib"
+    simpcat: "git://github.com/simp/pupmod-simp-concat"
     functions: "git://github.com/simp/pupmod-simp-functions"
     stdlib: "git://github.com/simp/puppetlabs-stdlib"
   symlinks:

--- a/build/pupmod-xwindows.spec
+++ b/build/pupmod-xwindows.spec
@@ -1,7 +1,7 @@
 Summary: XWindows Puppet Module
 Name: pupmod-xwindows
 Version: 4.1.0
-Release: 3
+Release: 4
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -13,6 +13,7 @@ Requires: puppet >= 3.3.0
 Requires: puppetlabs-stdlib >= 4.1.0-0
 Buildarch: noarch
 Requires: simp-bootstrap >= 4.2.0
+Requires: pupmod-simplib >= 1.0.0-0
 Obsoletes: pupmod-xwindows-test
 
 Prefix:"/etc/puppet/environments/simp/modules"
@@ -58,6 +59,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Mon Nov 09 2015 Chris Tessmer <chris.tessmer@onypoint.com> - 4.1.0-4
+- migration to simplib and simpcat (lib/ only)
+
 * Fri Jan 16 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-3
 - Changed puppet-server requirement to puppet
 
@@ -144,7 +148,7 @@ fi
 - Added a patch for checking the permissions on the GDM directory since having a
   strict root umask appears to mess things up.
 
-* Thu Oct 2 2009 Maintenance
+* Fri Oct 2 2009 Maintenance
 0.1-4
 - Fixed the gdm ordering issues.  GDM will now install properly and the conf
   file will get placed appropriately.


### PR DESCRIPTION
Before this commit, common SIMP-related custom functions were been kept
in either `simp-common` or `simp-functions`, and the `concat` function
was provided by the `simp-concat` module.  These functions are now
provides by the `simp-simplib` and `simp-simpcat` modules, respectively.

This update replaces all requirements in the RPM spec file,
metadata.json, or .fixtures.yml to reflect the migration to the new
modules.

SIMP-601 #comment Migrated `pupmod-simp-xwindows`.
SIMP-604 #comment Updated `pupmod-simp-xwindows`.